### PR TITLE
Implement silent node update action

### DIFF
--- a/apps/web/src/hooks/useCanvasOperations.ts
+++ b/apps/web/src/hooks/useCanvasOperations.ts
@@ -304,7 +304,7 @@ export function useCanvasOperations(options: UseCanvasOperationsOptions = {}): U
             // Update immediately during dragging for visual feedback
             if (change.dragging) {
               // Direct update without history for dragging
-              storeState.updateNode(change.id as NodeID, { position: change.position });
+              storeState.updateNodeSilently(change.id as NodeID, { position: change.position });
             } else {
               // Batch updates when drag ends for history recording
               batchPositionUpdate(change.id as NodeID, change.position);

--- a/apps/web/src/stores/selectorFactory.ts
+++ b/apps/web/src/stores/selectorFactory.ts
@@ -41,6 +41,7 @@ export const createCommonStoreSelector = () => (state: UnifiedStore) => ({
   // Node operations
   addNode: state.addNode,
   updateNode: state.updateNode,
+  updateNodeSilently: state.updateNodeSilently,
   deleteNode: state.deleteNode,
   
   // Arrow operations

--- a/apps/web/src/stores/unifiedStore.ts
+++ b/apps/web/src/stores/unifiedStore.ts
@@ -183,6 +183,33 @@ export const useUnifiedStore = create<UnifiedStore>()(
             }
           }),
 
+        updateNodeSilently: (id, updates) =>
+          set((state) => {
+            const node = state.nodes.get(id);
+            if (!node) return;
+
+            // Create a new node object to ensure immutability
+            const updatedNode = { ...node };
+
+            // Deep merge data if provided in updates
+            if (updates.data && node.data) {
+              updatedNode.data = {
+                ...node.data,
+                ...updates.data,
+              };
+              const { data, ...otherUpdates } = updates;
+              Object.assign(updatedNode, otherUpdates);
+            } else {
+              Object.assign(updatedNode, updates);
+            }
+
+            const newNodes = new Map(state.nodes);
+            newNodes.set(id, updatedNode);
+            state.nodes = newNodes;
+
+            state.dataVersion += 1;
+          }),
+
         deleteNode: (id) =>
           set((state) => {
             const node = state.nodes.get(id);

--- a/apps/web/src/stores/unifiedStore.types.ts
+++ b/apps/web/src/stores/unifiedStore.types.ts
@@ -139,6 +139,7 @@ export interface UnifiedStore {
   // Node operations
   addNode: (type: NodeKind, position: Vec2, initialData?: Record<string, unknown>) => NodeID;
   updateNode: (id: NodeID, updates: Partial<DomainNode>) => void;
+  updateNodeSilently: (id: NodeID, updates: Partial<DomainNode>) => void;
   deleteNode: (id: NodeID) => void;
   
   // Arrow operations


### PR DESCRIPTION
## Summary
- add `updateNodeSilently` action for non-historied updates
- expose new action in store selector factory and store types
- use silent updates during node drag for smoother UI

## Testing
- `pnpm lint` *(fails: 3 errors, 139 warnings)*
- `pnpm typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68498afbae188328a7a84b00bc65ff65