### PR TITLE
Add line range support to DB node reads

### DIFF
--- a/apps/web/src/__generated__/fields.ts
+++ b/apps/web/src/__generated__/fields.ts
@@ -196,6 +196,12 @@ export const GENERATED_FIELD_CONFIGS: GeneratedFieldConfigs = {
       required: false,
     },
     {
+      name: 'lines',
+      type: 'text',
+      label: 'lines',
+      required: false,
+    },
+    {
       name: 'data',
       type: 'textarea',
       label: 'data',

--- a/apps/web/src/__generated__/fields/DbFields.ts
+++ b/apps/web/src/__generated__/fields/DbFields.ts
@@ -58,6 +58,14 @@ export const dbFields: UnifiedFieldDefinition[] = [
     description: '"Single key or list of dot-separated keys to target within the JSON payload"',
   },
   {
+    name: 'lines',
+    type: 'text',
+    label: '"Lines"',
+    required: false,
+    placeholder: '"e.g., 1:120 or 5,10:20"',
+    description: '"Line selection or ranges to read (e.g., 1:120 or [\'10:20\'])"',
+  },
+  {
     name: 'data',
     type: 'textarea',
     label: '"Data"',

--- a/apps/web/src/__generated__/models/DbNode.ts
+++ b/apps/web/src/__generated__/models/DbNode.ts
@@ -9,6 +9,7 @@ export interface DbNodeData {
   operation: string;
   query?: string | undefined;
   keys?: any | undefined;
+  lines?: any | undefined;
   data?: Record<string, any> | undefined;
   serialize_json?: boolean | undefined;
   format?: string | undefined;
@@ -22,6 +23,7 @@ export const DbNodeDataSchema = z.object({
   operation: z.string().describe("Operation configuration"),
   query: z.string().optional().describe("Query configuration"),
   keys: z.any().optional().describe("Single key or list of dot-separated keys to target within the JSON payload"),
+  lines: z.any().optional().describe("Line selection or ranges to read (e.g., 1:120 or ['10:20'])"),
   data: z.record(z.any()).optional().describe("Data configuration"),
   serialize_json: z.boolean().optional().describe("Serialize structured data to JSON string (for backward compatibility)"),
   format: z.string().optional().describe("Data format (json, yaml, csv, text, etc.)"),

--- a/apps/web/src/__generated__/schemas.ts
+++ b/apps/web/src/__generated__/schemas.ts
@@ -68,6 +68,7 @@ export const DbSchema = z.object({
   operation: z.string(),
   query: z.string().optional(),
   keys: z.any().optional(),
+  lines: z.any().optional(),
   data: z.record(z.any()).optional(),
   serialize_json: z.boolean().optional(),
   format: z.string().optional()

--- a/dipeo/application/execution/handlers/db.py
+++ b/dipeo/application/execution/handlers/db.py
@@ -74,6 +74,37 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
                 produced_by=str(node.id),
             )
 
+        lines_value = getattr(node, "lines", None)
+
+        def _has_lines_spec(value: Any) -> bool:
+            if value is None:
+                return False
+            if isinstance(value, str):
+                return bool(value.strip())
+            if isinstance(value, (list, tuple, set)):
+                return any(item is not None for item in value)
+            if isinstance(value, dict):
+                return bool(value)
+            return True
+
+        lines_specified = _has_lines_spec(lines_value)
+
+        if lines_specified and node.operation != "read":
+            factory = get_envelope_factory()
+            return factory.error(
+                "The 'lines' option is only supported for read operations",
+                error_type="ValueError",
+                produced_by=str(node.id),
+            )
+
+        if lines_specified and getattr(node, "keys", None):
+            factory = get_envelope_factory()
+            return factory.error(
+                "Cannot combine 'lines' and 'keys' for database reads",
+                error_type="ValueError",
+                produced_by=str(node.id),
+            )
+
         # Validate file paths are provided
         file_paths = node.file
         if not file_paths:
@@ -202,6 +233,7 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
         processed_paths = self._expand_glob_patterns(processed_paths, base_dir)
 
         format_type = getattr(node, "format", None)
+        lines_spec = getattr(node, "lines", None) if node.operation == "read" else None
 
         if format_type and node.operation in ("write", "update"):
             adjusted_paths = []
@@ -259,6 +291,9 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
             if node.operation == "read" and len(processed_paths) > 1:
                 results = {}
                 serialize_json = getattr(node, "serialize_json", False)
+                line_metadata: dict[str, list[dict[str, int | None]]] = {}
+                total_lines_map: dict[str, int] = {}
+                partial_files: set[str] = set()
                 for file_path in processed_paths:
                     try:
                         result = await db_service.execute_operation(
@@ -266,19 +301,31 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
                             operation=node.operation,
                             value=input_val,
                             keys=keys,
+                            lines=lines_spec,
                         )
                         file_content = result["value"]
+                        metadata = result.get("metadata", {}) or {}
+                        partial_content = bool(metadata.get("partial_content"))
+                        total_lines = metadata.get("total_lines")
 
                         if isinstance(file_content, str):
-                            if format_type:
+                            if format_type and not partial_content:
                                 file_content = self._deserialize_data(file_content, format_type)
-                            elif serialize_json:
+                            elif serialize_json and not partial_content:
                                 try:
                                     file_content = json.loads(file_content)
                                 except json.JSONDecodeError:
                                     logger.warning(f"Failed to parse JSON from {file_path}")
 
                         results[file_path] = file_content
+
+                        line_ranges_meta = metadata.get("line_ranges")
+                        if line_ranges_meta is not None:
+                            line_metadata[file_path] = line_ranges_meta
+                        if partial_content:
+                            partial_files.add(file_path)
+                        if isinstance(total_lines, int):
+                            total_lines_map[file_path] = total_lines
                     except Exception as e:
                         logger.warning(f"Failed to read file {file_path}: {e}")
                         results[file_path] = None
@@ -290,6 +337,10 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
                     "file_count": len(processed_paths),
                     "format": format_type,
                     "serialize_json": serialize_json,
+                    "line_ranges": line_metadata or None,
+                    "partial": bool(partial_files),
+                    "partial_files": sorted(partial_files) if partial_files else None,
+                    "total_lines": total_lines_map or None,
                 }
 
             elif len(processed_paths) == 1:
@@ -299,13 +350,27 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
                     operation=node.operation,
                     value=input_val,
                     keys=keys,
+                    lines=lines_spec,
                 )
+
+                partial_content = False
+                total_lines = None
+                line_ranges_meta = None
 
                 if node.operation == "read":
                     output_value = result["value"]
-                    if isinstance(output_value, str) and format_type:
+                    metadata = result.get("metadata", {}) or {}
+                    partial_content = bool(metadata.get("partial_content"))
+                    total_lines = metadata.get("total_lines")
+                    line_ranges_meta = metadata.get("line_ranges")
+
+                    if isinstance(output_value, str) and format_type and not partial_content:
                         output_value = self._deserialize_data(output_value, format_type)
-                    elif isinstance(output_value, str) and getattr(node, "serialize_json", False):
+                    elif (
+                        isinstance(output_value, str)
+                        and getattr(node, "serialize_json", False)
+                        and not partial_content
+                    ):
                         try:
                             output_value = json.loads(output_value)
                         except json.JSONDecodeError:
@@ -325,6 +390,9 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
                     "serialize_json": serialize_json,
                     "format": format_type,
                     "operation": node.operation,
+                    "line_ranges": line_ranges_meta if node.operation == "read" else None,
+                    "partial": partial_content if node.operation == "read" else False,
+                    "total_lines": total_lines if node.operation == "read" else None,
                 }
 
             else:
@@ -357,6 +425,10 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
                 format=result.get("format"),
                 serialize_json=result.get("serialize_json", False),
                 glob=result.get("glob", False),
+                line_ranges=result.get("line_ranges"),
+                partial=result.get("partial", False),
+                partial_files=result.get("partial_files"),
+                total_lines=result.get("total_lines"),
             )
 
             return envelope
@@ -384,6 +456,9 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
                 operation=operation,
                 format=result.get("format"),
                 serialize_json=result.get("serialize_json", False),
+                line_ranges=result.get("line_ranges"),
+                partial=result.get("partial", False),
+                total_lines=result.get("total_lines"),
             )
 
             return envelope

--- a/dipeo/diagram_generated/graphql/node_mutations.py
+++ b/dipeo/diagram_generated/graphql/node_mutations.py
@@ -317,9 +317,13 @@ class CreateDbInput:
     
     
     keys: Optional[str] = None  # Single key or list of dot-separated keys to target within the JSON payload
-    
-    
-    
+
+
+
+    lines: Optional[strawberry.scalars.JSON] = None  # Line selection or ranges to read (e.g., 1:120 or ['10:20'])
+
+
+
     data: Optional[strawberry.scalars.JSON] = None  # Data configuration
     
     
@@ -363,9 +367,13 @@ class UpdateDbInput:
     
     
     keys: Optional[str] = None  # Single key or list of dot-separated keys to target within the JSON payload
-    
-    
-    
+
+
+
+    lines: Optional[strawberry.scalars.JSON] = None  # Line selection or ranges to read (e.g., 1:120 or ['10:20'])
+
+
+
     data: Optional[strawberry.scalars.JSON] = None  # Data configuration
     
     

--- a/dipeo/diagram_generated/graphql/strawberry_nodes.py
+++ b/dipeo/diagram_generated/graphql/strawberry_nodes.py
@@ -398,9 +398,13 @@ class DbDataType:
     
     
     keys: Optional[str] = None  # Single key or list of dot-separated keys to target within the JSON payload
-    
-    
-    
+
+
+
+    lines: Optional[JSONScalar] = None  # Line selection or ranges to read (e.g., 1:120 or ['10:20'])
+
+
+
     data: Optional[JSONScalar] = None  # Data configuration
     
     
@@ -453,13 +457,19 @@ class DbDataType:
         
         
         field_value = getattr(node, "keys", None)
-        
+
         # Direct assignment for other types
         field_values["keys"] = field_value
-        
-        
+
+
+        field_value = getattr(node, "lines", None)
+
+        # Convert dict/object fields to JSONScalar
+        field_values["lines"] = field_value
+
+
         field_value = getattr(node, "data", None)
-        
+
         # Convert dict/object fields to JSONScalar
         field_values["data"] = field_value
         

--- a/dipeo/diagram_generated/unified_nodes/db_node.py
+++ b/dipeo/diagram_generated/unified_nodes/db_node.py
@@ -45,7 +45,9 @@ class DbNode(BaseModel):
     query: Optional[str] = Field(default=None, description="Query configuration")
     
     keys: Optional[Any] = Field(default=None, description="Single key or list of dot-separated keys to target within the JSON payload")
-    
+
+    lines: Optional[Any] = Field(default=None, description="Line selection or ranges to read (e.g., 1:120 or ['10:20'])")
+
     data: Optional[Dict[str, Any]] = Field(default_factory=dict, description="Data configuration")
     
     serialize_json: Optional[bool] = Field(default=None, description="Serialize structured data to JSON string (for backward compatibility)")
@@ -81,6 +83,7 @@ class DbNode(BaseModel):
         data["operation"] = self.operation
         data["query"] = self.query
         data["keys"] = self.keys
+        data["lines"] = self.lines
         data["data"] = self.data
         data["serialize_json"] = self.serialize_json
         data["format"] = self.format

--- a/dipeo/infrastructure/shared/database/service.py
+++ b/dipeo/infrastructure/shared/database/service.py
@@ -24,9 +24,16 @@ class DBOperationsDomainService:
         self.validation_service = validation_service
 
     async def execute_operation(
-        self, db_name: str, operation: str, value: Any = None, keys: Any = None
+        self,
+        db_name: str,
+        operation: str,
+        value: Any = None,
+        keys: Any = None,
+        lines: Any = None,
     ) -> dict[str, Any]:
-        return await self.adapter.execute_operation(db_name, operation, value, keys)
+        return await self.adapter.execute_operation(
+            db_name, operation, value, keys, lines
+        )
 
     async def _get_db_file_path(self, db_name: str) -> str:
         return await self.adapter._get_db_file_path(db_name)

--- a/dipeo/models/src/nodes/db.spec.ts
+++ b/dipeo/models/src/nodes/db.spec.ts
@@ -79,6 +79,16 @@ export const dbSpec: NodeSpecification = {
       }
     },
     {
+      name: "lines",
+      type: "any",
+      required: false,
+      description: "Line selection or ranges to read (e.g., 1:120 or ['10:20'])",
+      uiConfig: {
+        inputType: "text",
+        placeholder: "e.g., 1:120 or 5,10:20"
+      }
+    },
+    {
       name: "data",
       type: "object",
       required: false,


### PR DESCRIPTION
## Summary
- add validation and execution-path handling for the new optional `lines` selector on DB read operations, including partial read metadata
- extend the database domain service, adapter, and validator layers to normalize requested line ranges, slice file content, and forbid incompatible options
- surface the new `lines` property through generated node models, GraphQL inputs/types, and the web UI field/schema definitions

## Testing
- `python -m compileall dipeo/application/execution/handlers/db.py dipeo/infrastructure/integrations/adapters/db_adapter.py dipeo/domain/integrations/db_services/db_operations_service.py dipeo/domain/integrations/validators/data_validator.py`


------
https://chatgpt.com/codex/tasks/task_e_68ce113925dc83289a8134534fbdcabe