### PR TITLE
Support Claude Code forked sessions in session pool

### DIFF
--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -33,6 +33,17 @@ persons:
     max_turns: 5  # Maximum conversation turns
 ```
 
+### Session Pooling Environment Variables
+
+- `DIPEO_CLAUDE_FORK_SESSION` – Controls how the Claude Code session pool
+  leverages the SDK's **fork session** capability when reconnecting to a logical
+  session ID.
+  - `auto` *(default)* – Enable forking when `DIPEO_SESSION_POOL_ENABLED=true`.
+  - `true` – Always request forking (requires an updated Claude Code SDK).
+  - `false` – Never request forking, keeping legacy behaviour.
+  This prevents pooled sessions from inheriting stale state when the SDK
+  reconnects to an existing logical session identifier.
+
 ## Supported Models
 
 - `claude-code` - Default Claude Code model


### PR DESCRIPTION
## Summary
- detect claude-code SDK fork-session support and enable it automatically for pooled sessions with an opt-out env toggle
- track server-provided session ids so pooled sessions update after forking while preserving their logical alias for logging
- document the new DIPEO_CLAUDE_FORK_SESSION environment variable for session-pool configuration

## Testing
- uv run ruff check dipeo/infrastructure/llm/providers/claude_code/transport/session_pool.py

------
https://chatgpt.com/codex/tasks/task_e_68d4a85a1ac48328b0ec4e93b35668f1