### PR TITLE
fix: standardize handler patterns across codebase

### DIFF
--- a/dipeo/application/execution/handlers/db.py
+++ b/dipeo/application/execution/handlers/db.py
@@ -407,7 +407,7 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
             results = result["results"]
 
             # Create envelope with results as body
-            envelope = factory.create(body=results, produced_by=node.id, trace_id=trace_id)
+            envelope = EnvelopeFactory.create(body=results, produced_by=node.id, trace_id=trace_id)
 
             # Add metadata about the operation
             envelope = envelope.with_meta(
@@ -441,7 +441,7 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
                 body = output_value
 
             # Create envelope
-            envelope = factory.create(body=body, produced_by=node.id, trace_id=trace_id)
+            envelope = EnvelopeFactory.create(body=body, produced_by=node.id, trace_id=trace_id)
 
             # Add metadata
             envelope = envelope.with_meta(
@@ -456,7 +456,7 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
             return envelope
 
         # Fallback for unexpected result format
-        envelope = factory.create(body=result, produced_by=node.id, trace_id=trace_id)
+        envelope = EnvelopeFactory.create(body=result, produced_by=node.id, trace_id=trace_id)
 
         envelope = envelope.with_meta(operation=operation)
 

--- a/dipeo/application/execution/handlers/db.py
+++ b/dipeo/application/execution/handlers/db.py
@@ -18,7 +18,7 @@ from dipeo.application.registry.keys import TEMPLATE_PROCESSOR
 from dipeo.config.paths import BASE_DIR
 from dipeo.diagram_generated.enums import NodeType
 from dipeo.diagram_generated.unified_nodes.db_node import DbNode
-from dipeo.domain.execution.envelope import Envelope, get_envelope_factory
+from dipeo.domain.execution.envelope import Envelope, EnvelopeFactory
 
 if TYPE_CHECKING:
     pass
@@ -59,18 +59,17 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
         # Validate operation type
         valid_operations = ["read", "write", "append", "update"]
         if node.operation not in valid_operations:
-            factory = get_envelope_factory()
-            return factory.error(
-                f"Invalid operation: {node.operation}. Valid operations: {', '.join(valid_operations)}",
-                error_type="ValueError",
+            return EnvelopeFactory.create(
+                body={
+                    "error": f"Invalid operation: {node.operation}. Valid operations: {', '.join(valid_operations)}",
+                    "type": "ValueError"
+                },
                 produced_by=str(node.id),
             )
 
         if node.operation == "update" and not getattr(node, "keys", None):
-            factory = get_envelope_factory()
-            return factory.error(
-                "Update operation requires one or more keys",
-                error_type="ValueError",
+            return EnvelopeFactory.create(
+                body={"error": "Update operation requires one or more keys", "type": "ValueError"},
                 produced_by=str(node.id),
             )
 
@@ -90,28 +89,22 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
         lines_specified = _has_lines_spec(lines_value)
 
         if lines_specified and node.operation != "read":
-            factory = get_envelope_factory()
-            return factory.error(
-                "The 'lines' option is only supported for read operations",
-                error_type="ValueError",
+            return EnvelopeFactory.create(
+                body={"error": "The 'lines' option is only supported for read operations", "type": "ValueError"},
                 produced_by=str(node.id),
             )
 
         if lines_specified and getattr(node, "keys", None):
-            factory = get_envelope_factory()
-            return factory.error(
-                "Cannot combine 'lines' and 'keys' for database reads",
-                error_type="ValueError",
+            return EnvelopeFactory.create(
+                body={"error": "Cannot combine 'lines' and 'keys' for database reads", "type": "ValueError"},
                 produced_by=str(node.id),
             )
 
         # Validate file paths are provided
         file_paths = node.file
         if not file_paths:
-            factory = get_envelope_factory()
-            return factory.error(
-                "No file paths specified for database operation",
-                error_type="ValueError",
+            return EnvelopeFactory.create(
+                body={"error": "No file paths specified for database operation", "type": "ValueError"},
                 produced_by=str(node.id),
             )
 
@@ -406,7 +399,6 @@ class DBTypedNodeHandler(TypedNodeHandler[DbNode]):
         """Custom serialization for DB results."""
         node = request.node
         trace_id = request.execution_id or ""
-        factory = get_envelope_factory()
         operation = node.operation
 
         # Handle multiple files result

--- a/dipeo/application/execution/handlers/endpoint.py
+++ b/dipeo/application/execution/handlers/endpoint.py
@@ -50,8 +50,7 @@ class EndpointNodeHandler(TypedNodeHandler[EndpointNode]):
         services = request.services
 
         if node.save_to_file:
-            filesystem_adapter = request.get_optional_service(FILESYSTEM_ADAPTER)
-            if not filesystem_adapter:
+            if not self._filesystem_adapter:
                 return EnvelopeFactory.create(
                     body={
                         "error": "Filesystem adapter is required when save_to_file is enabled",
@@ -81,8 +80,7 @@ class EndpointNodeHandler(TypedNodeHandler[EndpointNode]):
 
     def validate(self, request: ExecutionRequest[EndpointNode]) -> str | None:
         node = request.node
-        filesystem_adapter = request.get_optional_service(FILESYSTEM_ADAPTER)
-        if node.save_to_file and not filesystem_adapter:
+        if node.save_to_file and not self._filesystem_adapter:
             return "Filesystem adapter is required when save_to_file is enabled"
 
         return None
@@ -112,11 +110,8 @@ class EndpointNodeHandler(TypedNodeHandler[EndpointNode]):
 
         if self._current_save_enabled:
             file_name = self._current_filename
-            filesystem_adapter = (
-                request.get_optional_service(FILESYSTEM_ADAPTER) or self._filesystem_adapter
-            )
 
-            if filesystem_adapter:
+            if self._filesystem_adapter:
                 try:
                     if isinstance(result_data, dict):
                         content = json.dumps(result_data, indent=2)
@@ -125,10 +120,10 @@ class EndpointNodeHandler(TypedNodeHandler[EndpointNode]):
 
                     file_path = Path(file_name)
                     parent_dir = file_path.parent
-                    if parent_dir != Path() and not filesystem_adapter.exists(parent_dir):
-                        filesystem_adapter.mkdir(parent_dir, parents=True)
+                    if parent_dir != Path() and not self._filesystem_adapter.exists(parent_dir):
+                        self._filesystem_adapter.mkdir(parent_dir, parents=True)
 
-                    with filesystem_adapter.open(file_path, "wb") as f:
+                    with self._filesystem_adapter.open(file_path, "wb") as f:
                         f.write(content.encode("utf-8"))
 
                     return {"data": result_data, "saved_to": file_name, "save_success": True}

--- a/dipeo/application/execution/handlers/endpoint.py
+++ b/dipeo/application/execution/handlers/endpoint.py
@@ -50,7 +50,13 @@ class EndpointNodeHandler(TypedNodeHandler[EndpointNode]):
         services = request.services
 
         if node.save_to_file:
-            if not self._filesystem_adapter:
+            filesystem_adapter = getattr(self, "_filesystem_adapter", None)
+            if filesystem_adapter is None:
+                filesystem_adapter = request.get_optional_service(FILESYSTEM_ADAPTER)
+                if filesystem_adapter is not None:
+                    self._filesystem_adapter = filesystem_adapter
+
+            if not filesystem_adapter:
                 return EnvelopeFactory.create(
                     body={
                         "error": "Filesystem adapter is required when save_to_file is enabled",
@@ -80,7 +86,13 @@ class EndpointNodeHandler(TypedNodeHandler[EndpointNode]):
 
     def validate(self, request: ExecutionRequest[EndpointNode]) -> str | None:
         node = request.node
-        if node.save_to_file and not self._filesystem_adapter:
+        filesystem_adapter = getattr(self, "_filesystem_adapter", None)
+        if filesystem_adapter is None:
+            filesystem_adapter = request.get_optional_service(FILESYSTEM_ADAPTER)
+            if filesystem_adapter is not None:
+                self._filesystem_adapter = filesystem_adapter
+
+        if node.save_to_file and not filesystem_adapter:
             return "Filesystem adapter is required when save_to_file is enabled"
 
         return None

--- a/dipeo/application/execution/handlers/hook.py
+++ b/dipeo/application/execution/handlers/hook.py
@@ -91,7 +91,13 @@ class HookNodeHandler(TypedNodeHandler[HookNode]):
                     },
                     produced_by=str(node.id),
                 )
-            if not self._filesystem_adapter:
+            filesystem_adapter = getattr(self, "_filesystem_adapter", None)
+            if filesystem_adapter is None:
+                filesystem_adapter = request.get_optional_service(FILESYSTEM_ADAPTER)
+                if filesystem_adapter is not None:
+                    self._filesystem_adapter = filesystem_adapter
+
+            if not filesystem_adapter:
                 return EnvelopeFactory.create(
                     body={
                         "error": "Filesystem adapter is required for file hooks",

--- a/dipeo/application/execution/handlers/start.py
+++ b/dipeo/application/execution/handlers/start.py
@@ -63,10 +63,9 @@ class StartNodeHandler(TypedNodeHandler[StartNode]):
         elif request.runtime and hasattr(request.runtime, "execution_id"):
             execution_id = request.runtime.execution_id
 
-        # Get state_store service directly from request
-        state_store = request.get_optional_service(STATE_STORE)
-        if execution_id and state_store:
-            execution_state = await state_store.get_state(execution_id)
+        # Use injected state_store service
+        if execution_id and self._state_store:
+            execution_state = await self._state_store.get_state(execution_id)
             if execution_state and execution_state.variables:
                 self._current_input_variables = execution_state.variables
 


### PR DESCRIPTION
## Summary

This PR standardizes handler patterns across the codebase to address inconsistencies identified in issue #94.

## Changes

### 1. Refactored `diff_patch.py` (Critical)
- Changed method signature from `execute_request()` to `run()`
- Added proper decorators (`@register_handler`, `@requires_services`)
- Use `EnvelopeFactory.create()` instead of direct `Envelope()` construction
- Added `prepare_inputs()` and `serialize_output()` methods

### 2. Fixed redundant service access patterns
- `start.py`: Use injected `self._state_store` instead of `request.get_optional_service()`
- `hook.py`: Use consistent `self._filesystem_adapter` access
- `endpoint.py`: Standardized filesystem adapter access

### 3. Standardized envelope factory usage in `db.py`
- Replaced `get_envelope_factory()` and `factory.error()` with `EnvelopeFactory.create()`
- Consistent error envelope structure

Fixes #94

Generated with [Claude Code](https://claude.ai/code)