### PR TITLE
Surface memory selection as tool result for Claude Code

### DIFF
--- a/dipeo/domain/conversation/person.py
+++ b/dipeo/domain/conversation/person.py
@@ -188,7 +188,15 @@ class Person:
             )
 
             if selected_messages is not None:
-                messages_for_completion = selected_messages
+                service_value = getattr(self.llm_config.service, "value", str(self.llm_config.service))
+                service_slug = str(service_value).replace("_", "-")
+
+                if service_slug in {"claude-code", "claude-code-custom"}:
+                    if selected_messages:
+                        llm_options["memory_tool_messages"] = selected_messages
+                    messages_for_completion = []
+                else:
+                    messages_for_completion = selected_messages
 
         result, incoming, response = await self.complete(
             prompt=prompt,

--- a/dipeo/infrastructure/llm/drivers/service.py
+++ b/dipeo/infrastructure/llm/drivers/service.py
@@ -474,6 +474,7 @@ class LLMInfraService(LoggingMixin, InitializationMixin, LLMServicePort):
                 messages = []
 
             execution_phase = kwargs.pop("execution_phase", None)
+            memory_tool_messages = kwargs.pop("memory_tool_messages", None)
 
             # Use the explicit service parameter if provided, otherwise infer from model
             if service_name:
@@ -492,6 +493,16 @@ class LLMInfraService(LoggingMixin, InitializationMixin, LLMServicePort):
             # Add person_name back only for Claude Code
             if service_name == "claude_code" and "person_name" in kwargs:
                 client_kwargs["person_name"] = kwargs["person_name"]
+
+            if memory_tool_messages is not None:
+                service_slug = (
+                    service_name.value
+                    if hasattr(service_name, "value")
+                    else str(service_name)
+                )
+                normalized_slug = service_slug.replace("-", "_")
+                if normalized_slug in {"claude_code", "claude_code_custom"}:
+                    client_kwargs["memory_tool_messages"] = memory_tool_messages
 
             if execution_phase:
                 client_kwargs["execution_phase"] = execution_phase


### PR DESCRIPTION
## Summary
- pass memory-selected messages through person completion as tool payloads for Claude Code providers
- propagate memory tool payloads through the LLM infra service into the Claude Code unified client
- inject a formatted select_memory_messages tool result block ahead of prompts and stash message ids in response metadata

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9dfed41088328a9abf3bd08c2674a