### PR TITLE
refactor: remove redundant type aliases from type_defs.py

### DIFF
--- a/dipeo/domain/type_defs.py
+++ b/dipeo/domain/type_defs.py
@@ -94,36 +94,24 @@ class Error:
 
 
 # JSON type definitions - using limited depth to avoid Pydantic recursion issues
-# NOTE: Pydantic doesn't handle recursive types well, so we use a practical approach
+# NOTE: Pydantic v2 has better support for recursive types than v1
 
 # JSON primitive types
 JsonPrimitive = str | int | float | bool | None
-SimpleJsonValue = JsonPrimitive  # Alias for compatibility
 
 # For complex nested structures, we use Any to avoid recursion issues
-# This is a pragmatic solution until Pydantic better supports recursive types
+# This is a pragmatic solution for deeply nested JSON structures
 JsonDict = dict[str, Any]  # Allows any nested structure
 JsonList = list[Any]  # Allows any nested list
 
 # Main JSON value type - covers most practical cases
 JsonValue = JsonPrimitive | JsonDict | JsonList
 
-# Type aliases for clarity
-JsonObject = JsonDict  # Alias for JSON objects
-JsonArray = JsonList  # Alias for JSON arrays
-
-# For backward compatibility
-JsonAny = Any  # Will gradually migrate to more specific types
-
 __all__ = [
     "Error",
-    "JsonAny",
-    "JsonArray",
     "JsonDict",
     "JsonList",
-    "JsonObject",
     "JsonPrimitive",
     "JsonValue",
     "Result",
-    "SimpleJsonValue",
 ]

--- a/dipeo/infrastructure/llm/drivers/pydantic_compiler.py
+++ b/dipeo/infrastructure/llm/drivers/pydantic_compiler.py
@@ -27,7 +27,7 @@ def compile_pydantic_model(code_str: str) -> type[BaseModel] | None:
             auto_imports = """from pydantic import BaseModel, Field, ConfigDict
 from typing import List, Optional, Dict, Any, Union
 from enum import Enum
-from dipeo.domain.type_defs import JsonValue, JsonDict, JsonList, SimpleJsonValue
+from dipeo.domain.type_defs import JsonValue, JsonDict, JsonList, JsonPrimitive
 
 """
             code_str = auto_imports + code_str
@@ -54,9 +54,9 @@ from dipeo.domain.type_defs import JsonValue, JsonDict, JsonList, SimpleJsonValu
             "JsonValue": __import__("dipeo.domain.type_defs", fromlist=["JsonValue"]).JsonValue,
             "JsonDict": __import__("dipeo.domain.type_defs", fromlist=["JsonDict"]).JsonDict,
             "JsonList": __import__("dipeo.domain.type_defs", fromlist=["JsonList"]).JsonList,
-            "SimpleJsonValue": __import__(
-                "dipeo.domain.type_defs", fromlist=["SimpleJsonValue"]
-            ).SimpleJsonValue,
+            "JsonPrimitive": __import__(
+                "dipeo.domain.type_defs", fromlist=["JsonPrimitive"]
+            ).JsonPrimitive,
         }
 
         # Parse the code to find class definitions


### PR DESCRIPTION
Fixes #126

## Summary

Removed redundant type aliases that were barely used and added unnecessary complexity to the codebase.

## Changes

- ✅ Removed `SimpleJsonValue` (replaced with `JsonPrimitive`)
- ✅ Removed `JsonObject` (redundant alias for `JsonDict`)
- ✅ Removed `JsonArray` (redundant alias for `JsonList`)
- ✅ Removed `JsonAny` (deprecated, use `Any` directly)
- ✅ Updated pydantic_compiler.py to use `JsonPrimitive`
- ✅ Updated `__all__` exports in type_defs.py
- ✅ Updated comment about Pydantic v2 recursive type support

## Testing

Successfully tested with:
- `make codegen` - Code generation completed without errors
- `make apply-test` - Server validation passed

These aliases were barely used and the remaining core types (`JsonValue`, `JsonDict`, `JsonList`, `JsonPrimitive`) provide all necessary JSON type definitions.

Generated with [Claude Code](https://claude.ai/code)