### PR TITLE
Consolidate EventManager and EventPipeline implementations

### DIFF
--- a/dipeo/application/execution/typed_execution_context.py
+++ b/dipeo/application/execution/typed_execution_context.py
@@ -12,7 +12,7 @@ from dipeo.diagram_generated import NodeID, NodeType, Status
 from dipeo.domain.diagram.models.executable_diagram import ExecutableDiagram
 from dipeo.domain.events.unified_ports import EventBus
 from dipeo.domain.execution.envelope import Envelope
-from dipeo.domain.execution.event_manager import EventManager
+from dipeo.application.execution.event_pipeline import EventPipeline
 from dipeo.domain.execution.execution_context import ExecutionContext as ExecutionContextProtocol
 from dipeo.domain.execution.state_tracker import StateTracker
 from dipeo.domain.execution.token_manager import TokenManager
@@ -34,7 +34,7 @@ class TypedExecutionContext(ExecutionContextProtocol):
 
     _token_manager: TokenManager = field(init=False)
     _state_tracker: StateTracker = field(init=False)
-    _event_manager: EventManager = field(init=False)
+    _event_pipeline: EventPipeline = field(init=False)
     _variables: dict[str, Any] = field(default_factory=dict)
     _metadata: dict[str, Any] = field(default_factory=dict)
     _current_node_id: NodeID | None = None
@@ -49,7 +49,7 @@ class TypedExecutionContext(ExecutionContextProtocol):
     def __post_init__(self):
         self._state_tracker = StateTracker()
         self._token_manager = TokenManager(self.diagram, execution_tracker=self._state_tracker)
-        self._event_manager = EventManager(
+        self._event_pipeline = EventPipeline(
             execution_id=self.execution_id,
             diagram_id=self.diagram_id,
             event_bus=self.event_bus,
@@ -68,8 +68,8 @@ class TypedExecutionContext(ExecutionContextProtocol):
         return self._token_manager
 
     @property
-    def events(self) -> EventManager:
-        return self._event_manager
+    def events(self) -> EventPipeline:
+        return self._event_pipeline
 
     def current_epoch(self) -> int:
         return self._token_manager.current_epoch()

--- a/dipeo/domain/CLAUDE.md
+++ b/dipeo/domain/CLAUDE.md
@@ -44,7 +44,7 @@ Pure business logic following DDD and hexagonal architecture.
 - **Resolution**: RuntimeInputResolver, TransformationEngine, NodeStrategies
 - **State Management**: StateTracker, ExecutionTracker
 - **Token Management**: TokenManager, TokenTypes
-- **Event Management**: EventManager for execution events
+- **Event Management**: EventManager (DEPRECATED - use EventPipeline from application layer)
 - **Rules**: ConnectionRules, TransformRules
 - **Context**: ExecutionContext management
 - **Envelope**: EnvelopeFactory for unified output pattern
@@ -171,7 +171,8 @@ from dipeo.domain.cc_translate.phase_coordinator import PhaseCoordinator  # Clau
 from dipeo.domain.cc_translate.convert.converter import Converter
 from dipeo.domain.execution.resolution import RuntimeInputResolver, TransformationEngine
 from dipeo.domain.execution.envelope import EnvelopeFactory  # Unified output pattern
-from dipeo.domain.execution.event_manager import EventManager
+from dipeo.application.execution.event_pipeline import EventPipeline  # RECOMMENDED: Use EventPipeline instead of EventManager
+from dipeo.domain.execution.event_manager import EventManager  # DEPRECATED: Use EventPipeline instead
 from dipeo.domain.execution.state_tracker import StateTracker
 from dipeo.domain.execution.token_manager import TokenManager
 from dipeo.domain.events import EventBus  # Unified event protocol

--- a/dipeo/domain/execution/event_manager.py
+++ b/dipeo/domain/execution/event_manager.py
@@ -1,10 +1,15 @@
 """Event management for execution context.
 
+DEPRECATED: This module is deprecated. Use EventPipeline from
+dipeo.application.execution.event_pipeline instead, which provides
+the same interface with enhanced features (sequence tracking, metrics).
+
 This module provides focused event operations as a domain concern,
 managing the emission of execution and node lifecycle events.
 """
 
 import logging
+import warnings
 
 from dipeo.config.base_logger import get_module_logger
 from typing import TYPE_CHECKING, Any, Optional
@@ -33,6 +38,12 @@ logger = get_module_logger(__name__)
 class EventManager:
     """Manages event emission for execution context.
 
+    DEPRECATED: Use EventPipeline from dipeo.application.execution.event_pipeline
+    instead. EventPipeline provides the same interface with enhanced features:
+    - Sequence tracking for idempotency
+    - Event metrics and statistics
+    - Enhanced metadata management
+
     Responsibilities:
     - Execution lifecycle events
     - Node execution events
@@ -52,12 +63,20 @@ class EventManager:
     ):
         """Initialize the event manager.
 
+        DEPRECATED: Use EventPipeline instead.
+
         Args:
             execution_id: The execution identifier
             diagram_id: The diagram identifier
             event_bus: Optional event bus for publishing events
             state_tracker: Optional state tracker for accessing node states
         """
+        warnings.warn(
+            "EventManager is deprecated. Use EventPipeline from "
+            "dipeo.application.execution.event_pipeline instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.execution_id = execution_id
         self.diagram_id = diagram_id
         self.event_bus = event_bus


### PR DESCRIPTION
Consolidates duplicate event emission implementations by:

- Migrating TypedExecutionContext to use EventPipeline instead of EventManager
- Adding public API methods to EventPipeline for backward compatibility
- Deprecating EventManager with clear warning messages
- Updating documentation to reflect the consolidation

EventPipeline now provides the same interface with enhanced features:
- Sequence tracking for idempotency
- Event metrics and statistics
- Enhanced metadata management

Closes #133

---

Generated with [Claude Code](https://claude.ai/code)