### PR TITLE
fix: resolve make codegen issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,9 @@ parse-typescript:
 	@rm -rf temp/core temp/specifications temp/frontend temp/codegen temp/nodes temp/utilities temp/*.json 2>/dev/null || true
 	@echo "Parsing TypeScript models..."
 	@if command -v dipeo >/dev/null 2>&1; then \
-		dipeo run projects/codegen/diagrams/parse_typescript_batch_direct --light --debug --simple --timeout=20; \
+		DIPEO_BASE_DIR=$(shell pwd) dipeo run projects/codegen/diagrams/parse_typescript_batch_direct --light --debug --simple --timeout=20; \
 	else \
-		uv run python -m dipeo_server.cli run projects/codegen/diagrams/parse_typescript_batch_direct --light --debug --timeout=20; \
+		DIPEO_BASE_DIR=$(shell pwd) uv run dipeo run projects/codegen/diagrams/parse_typescript_batch_direct --light --debug --timeout=20; \
 	fi
 	@echo "✓ TypeScript parsing complete"
 
@@ -84,9 +84,9 @@ parse-typescript:
 codegen: parse-typescript
 	@echo "Starting code generation..."
 	@if command -v dipeo >/dev/null 2>&1; then \
-		dipeo run projects/codegen/diagrams/generate_all --light --debug --simple --timeout=35; \
+		DIPEO_BASE_DIR=$(shell pwd) dipeo run projects/codegen/diagrams/generate_all --light --debug --simple --timeout=35; \
 	else \
-		uv run python -m dipeo_server.cli run projects/codegen/diagrams/generate_all --light --debug --timeout=35; \
+		DIPEO_BASE_DIR=$(shell pwd) uv run dipeo run projects/codegen/diagrams/generate_all --light --debug --timeout=35; \
 	fi
 	@echo "✓ Code generation complete. Next: make apply-test→ make graphql-schema"
 

--- a/projects/codegen/diagrams/parse_typescript_batch_direct.light.yaml
+++ b/projects/codegen/diagrams/parse_typescript_batch_direct.light.yaml
@@ -111,6 +111,12 @@ nodes:
                 # Skip dummy entry
                 if file_path == "_dummy":
                     continue
+
+                # Skip if parse_result is not a dict (error string)
+                if not isinstance(parse_result, dict):
+                    print(f"Warning: Skipping {file_path} - parse error: {parse_result}")
+                    continue
+
                 # Get relative path from models_dir
                 if file_path.startswith(models_dir):
                     relative_path = os.path.relpath(file_path, models_dir)
@@ -128,8 +134,9 @@ nodes:
 
                 # Save the parsed result to cache
                 try:
+                    ast_data = parse_result.get('ast', {})
                     with open(cache_path, 'w', encoding='utf-8') as f:
-                        json.dump(parse_result['ast'], f, indent=2)
+                        json.dump(ast_data, f, indent=2)
                     cached_count += 1
                 except Exception as e:
                     print(f"Warning: Failed to cache {file_path}: {e}")


### PR DESCRIPTION
Fixes #137

## Changes
- Fix Makefile CLI entry point (use `uv run dipeo` instead of `python -m dipeo_server.cli`)
- Add DIPEO_BASE_DIR environment variable to codegen commands
- Improve error handling in TypeScript batch parser

## Testing
Changes verified syntactically. Local testing recommended to confirm full codegen pipeline.

Generated with [Claude Code](https://claude.ai/code)