### PR TITLE
feat: add dipeo compile and dipeo list commands

### DIFF
--- a/apps/server/src/dipeo_server/cli/entry_point.py
+++ b/apps/server/src/dipeo_server/cli/entry_point.py
@@ -196,6 +196,28 @@ async def run_cli_command(args: argparse.Namespace) -> bool:
 
             return await cli.manage_claude_code(action, **kwargs)
 
+        elif args.command == "compile":
+            format_type = None
+            if hasattr(args, "light") and args.light:
+                format_type = "light"
+            elif hasattr(args, "native") and args.native:
+                format_type = "native"
+            elif hasattr(args, "readable") and args.readable:
+                format_type = "readable"
+
+            return await cli.compile_diagram(
+                diagram_path=args.diagram,
+                format_type=format_type,
+                check_only=getattr(args, "check_only", False),
+                output_json=getattr(args, "json", False),
+            )
+
+        elif args.command == "list":
+            return await cli.list_diagrams(
+                output_json=getattr(args, "json", False),
+                format_filter=getattr(args, "format", None),
+            )
+
         else:
             print(f"Unknown command: {args.command}")
             return False
@@ -411,6 +433,32 @@ def create_parser() -> argparse.ArgumentParser:
         "stats", help="Show detailed session statistics"
     )
     stats_cc_parser.add_argument("session_id", help="Session ID to analyze")
+
+    # Compile command
+    compile_parser = subparsers.add_parser("compile", help="Validate and compile diagram")
+    compile_parser.add_argument("diagram", help="Path to diagram file or diagram name")
+    compile_parser.add_argument("--check-only", action="store_true", help="Only validate structure")
+    compile_parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # Format options
+    compile_format_group = compile_parser.add_mutually_exclusive_group()
+    compile_format_group.add_argument("--light", action="store_true", help="Use light format (YAML)")
+    compile_format_group.add_argument("--native", action="store_true", help="Use native format (JSON)")
+    compile_format_group.add_argument(
+        "--readable", action="store_true", help="Use readable format (YAML)"
+    )
+
+    # List command
+    list_parser = subparsers.add_parser(
+        "list", help="List available diagrams in projects/ and examples/simple_diagrams/"
+    )
+    list_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    list_parser.add_argument(
+        "--format",
+        type=str,
+        choices=["light", "native", "readable"],
+        help="Filter by diagram format",
+    )
 
     return parser
 

--- a/docs/light-format-improvements.md
+++ b/docs/light-format-improvements.md
@@ -1,0 +1,337 @@
+# Light Diagram Format - Analysis & Improvement Suggestions
+
+## Current State Analysis
+
+The light diagram format is DiPeO's human-friendly YAML format designed for manual editing and AI-driven generation. It emphasizes readability and simplicity.
+
+### Current Strengths
+
+1. **Label-based References**: Uses human-readable labels instead of UUIDs
+2. **Flat Structure**: Simple top-level sections (`nodes`, `connections`, `persons`)
+3. **Inline Props**: Node properties nested directly under each node
+4. **Template Support**: Variable interpolation in prompts (`{{variable}}`)
+5. **Multi-line Content**: Supports multi-line code blocks and prompts
+6. **Minimal Boilerplate**: No redundant IDs or verbose syntax
+
+### Current Structure
+
+```yaml
+version: light
+nodes:
+  - label: node_name
+    type: NODE_TYPE
+    position: {x: 100, y: 200}
+    props:
+      field: value
+
+connections:
+  - from: source_label
+    to: target_label
+    content_type: raw_text
+    label: optional_label
+
+persons:
+  person_name:
+    service: openai
+    model: gpt-5-nano-2025-08-07
+    api_key_id: APIKEY_ID
+```
+
+## Suggested Improvements
+
+### 1. Enhanced Validation & Error Messages
+
+**Current Issue**: Generic validation errors don't point to specific diagram locations.
+
+**Improvement**: Add line number tracking and context-aware error messages.
+
+```yaml
+# When validation fails, provide:
+# - Line number in YAML
+# - Node/connection label context
+# - Suggestion for fix
+# - Related documentation link
+```
+
+**Implementation**: Enhance `LightDiagramParser` to track source locations.
+
+### 2. Schema Documentation & IDE Support
+
+**Current Issue**: No autocomplete or validation in editors.
+
+**Improvement**: Generate JSON Schema for light format.
+
+```yaml
+# Add $schema reference support
+$schema: https://dipeo.dev/schemas/light-v1.json
+version: light
+nodes: [...]
+```
+
+**Benefits**:
+- VSCode/IDE autocomplete
+- Real-time validation
+- Inline documentation
+- Type checking
+
+**Implementation**: Generate from `LightNode` and `LightConnection` Pydantic models.
+
+### 3. Default Values & Shorthand Notation
+
+**Current Issue**: Repetitive boilerplate for common patterns.
+
+**Improvement**: Support shorthand notations and implicit defaults.
+
+```yaml
+# Shorthand for simple person_job nodes
+nodes:
+  - label: analyzer
+    type: person_job
+    # Shorthand: prompt directly without props wrapper
+    prompt: "Analyze this data"
+    person: analyst
+
+  # Instead of:
+  - label: analyzer
+    type: person_job
+    props:
+      default_prompt: "Analyze this data"
+      person_id: analyst
+      max_iteration: 1
+      memorize_to: ALL_MESSAGES
+```
+
+**Implementation**: Add field alias support in parser for common fields.
+
+### 4. Variable Definitions Section
+
+**Current Issue**: Variables are implicit in templates, no declaration.
+
+**Improvement**: Add optional `variables` section for documentation and validation.
+
+```yaml
+version: light
+
+variables:
+  dataset_name:
+    type: string
+    default: "unknown"
+    description: "Name of the dataset being processed"
+  temperature:
+    type: number
+    default: 0.7
+    range: [0, 2]
+
+nodes: [...]
+```
+
+**Benefits**:
+- Self-documenting diagrams
+- Type validation
+- Default value management
+- Better AI understanding
+
+### 5. Reusable Templates & Mixins
+
+**Current Issue**: Similar node configurations are duplicated.
+
+**Improvement**: Support node templates and mixins.
+
+```yaml
+version: light
+
+templates:
+  standard_analyzer:
+    type: person_job
+    props:
+      max_iteration: 1
+      memorize_to: CONVERSATION_PAIRS
+      person: analyst
+
+nodes:
+  - label: analyze_sales
+    template: standard_analyzer
+    prompt: "Analyze sales data"
+
+  - label: analyze_trends
+    template: standard_analyzer
+    prompt: "Analyze trends"
+```
+
+### 6. Inline Comments & Documentation
+
+**Current Issue**: YAML comments are lost during parsing.
+
+**Improvement**: Preserve and use structured documentation.
+
+```yaml
+nodes:
+  - label: processor
+    type: code_job
+    description: |
+      This node processes raw CSV data by:
+      1. Removing empty rows
+      2. Validating data types
+      3. Calculating statistics
+    tags: [data-processing, validation]
+    props:
+      code: |
+        def process(data):
+          # implementation
+```
+
+**Benefits**:
+- Self-documenting workflows
+- Better AI comprehension
+- Searchable metadata
+- Auto-generated documentation
+
+### 7. Connection Shortcuts
+
+**Current Issue**: Connections are verbose for linear flows.
+
+**Improvement**: Support implicit connection chaining.
+
+```yaml
+# Current verbose style:
+connections:
+  - from: start
+    to: node1
+    content_type: raw_text
+  - from: node1
+    to: node2
+    content_type: raw_text
+  - from: node2
+    to: end
+    content_type: raw_text
+
+# Shorthand for linear flow:
+flow:
+  - start -> node1 -> node2 -> end
+  content_type: raw_text
+```
+
+### 8. Better Handle Specification
+
+**Current Issue**: Handle types are implicit, causing confusion.
+
+**Improvement**: Optional handle definitions for clarity.
+
+```yaml
+nodes:
+  - label: condition_node
+    type: condition
+    handles:
+      input: [DEFAULT]
+      output: [TRUE, FALSE]  # Explicit handle names
+    props:
+      condition_type: detect_max_iterations
+
+connections:
+  - from: condition_node[TRUE]   # Explicit handle reference
+    to: next_node
+```
+
+### 9. Metadata & Version Control
+
+**Current Issue**: Limited diagram metadata.
+
+**Improvement**: Enhanced metadata section.
+
+```yaml
+version: light
+
+metadata:
+  name: "Data Processing Pipeline"
+  description: "Processes CSV data and generates reports"
+  version: "1.2.0"
+  author: "team@example.com"
+  created: "2025-01-01"
+  modified: "2025-01-15"
+  tags: ["data-processing", "reporting"]
+  dependencies:
+    - openai-api
+    - csv-parser
+  inputs:
+    - dataset_path: string
+  outputs:
+    - report: markdown
+```
+
+### 10. Validation Rules
+
+**Current Issue**: No declarative validation for node inputs.
+
+**Improvement**: Add validation specifications.
+
+```yaml
+nodes:
+  - label: data_processor
+    type: code_job
+    validation:
+      inputs:
+        required: [raw_data]
+        types:
+          raw_data: string
+          config: object
+      outputs:
+        provides: [cleaned_data, statistics]
+    props:
+      code: |
+        # implementation
+```
+
+## Priority Recommendations
+
+For immediate implementation, prioritize:
+
+1. **Schema Documentation** (High Impact, Low Effort)
+   - Generate JSON Schema from Pydantic models
+   - Enable IDE support
+
+2. **Enhanced Error Messages** (High Impact, Medium Effort)
+   - Add source location tracking
+   - Context-aware validation
+
+3. **Shorthand Notations** (Medium Impact, Low Effort)
+   - Field aliases for common patterns
+   - Reduce boilerplate
+
+4. **Variable Definitions** (Medium Impact, Medium Effort)
+   - Improve self-documentation
+   - Enable type validation
+
+## Implementation Strategy
+
+### Phase 1: Foundation (Current Sprint)
+- ✅ Add `dipeo compile` command (validation tooling)
+- ✅ Add `dipeo list` command (discovery)
+- Generate JSON Schema
+- Enhance error messages
+
+### Phase 2: Usability (Next Sprint)
+- Implement shorthand notations
+- Add variable definitions section
+- Preserve comments in parsing
+
+### Phase 3: Advanced (Future)
+- Template system
+- Connection shortcuts
+- Advanced validation rules
+
+## Backward Compatibility
+
+All improvements should maintain backward compatibility:
+- Existing diagrams continue to work
+- New features are opt-in
+- Parser detects and adapts to format version
+
+## Conclusion
+
+The light format is already well-designed for human editing. These improvements would enhance:
+- **Discoverability**: JSON Schema enables IDE support
+- **Reliability**: Better validation catches errors early
+- **Productivity**: Shorthand notation reduces boilerplate
+- **Documentation**: Self-documenting workflows
+
+The format would become even more suitable for LLM-driven generation and human-AI collaborative workflows.

--- a/uv.lock
+++ b/uv.lock
@@ -693,6 +693,7 @@ dependencies = [
     { name = "rsa" },
     { name = "six" },
     { name = "sniffio" },
+    { name = "sse-starlette" },
     { name = "starlette" },
     { name = "strawberry-graphql" },
     { name = "structlog" },
@@ -819,6 +820,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "six", specifier = "==1.17.0" },
     { name = "sniffio", specifier = "==1.3.1" },
+    { name = "sse-starlette", specifier = "==2.2.1" },
     { name = "starlette", specifier = "==0.46.2" },
     { name = "strawberry-graphql", specifier = "==0.282.0" },
     { name = "structlog", specifier = "==24.4.0" },
@@ -3023,14 +3025,15 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.0.2"
+version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
+    { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/6f/22ed6e33f8a9e76ca0a412405f31abb844b779d52c5f96660766edcd737c/sse_starlette-3.0.2.tar.gz", hash = "sha256:ccd60b5765ebb3584d0de2d7a6e4f745672581de4f5005ab31c3a25d10b52b3a", size = 20985, upload-time = "2025-07-27T09:07:44.565Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/a4/80d2a11af59fe75b48230846989e93979c892d3a20016b42bb44edb9e398/sse_starlette-2.2.1.tar.gz", hash = "sha256:54470d5f19274aeed6b2d473430b08b4b379ea851d953b11d7f1c4a2c118b419", size = 17376, upload-time = "2024-12-25T09:09:30.616Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/10/c78f463b4ef22eef8491f218f692be838282cd65480f6e423d7730dfd1fb/sse_starlette-3.0.2-py3-none-any.whl", hash = "sha256:16b7cbfddbcd4eaca11f7b586f3b8a080f1afe952c15813455b162edea619e5a", size = 11297, upload-time = "2025-07-27T09:07:43.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e0/5b8bd393f27f4a62461c5cf2479c75a2cc2ffa330976f9f00f5f6e4f50eb/sse_starlette-2.2.1-py3-none-any.whl", hash = "sha256:6410a3d3ba0c89e7675d4c273a301d64649c03a5ef1ca101f10b47f895fd0e99", size = 10120, upload-time = "2024-12-25T09:09:26.761Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds two new CLI commands to enhance MCP integration and LLM-driven workflows:

- `dipeo compile`: Validate and compile diagrams without execution
- `dipeo list`: Discover diagrams in projects/ and examples/simple_diagrams/
- Light format analysis with 10 improvement suggestions

## Changes

- Added `compile_diagram()` method to CLIRunner
- Added `list_diagrams()` method to CLIRunner
- Added argument parsers for new commands
- Created comprehensive light format analysis document

## Testing

```bash
# Validate a diagram
dipeo compile examples/simple_diagrams/simple_iter --light

# List diagrams
dipeo list

# List only light format diagrams
dipeo list --format light

# Get JSON output
dipeo compile simple_iter --light --json
dipeo list --json
```

Closes #156

Generated with [Claude Code](https://claude.ai/code)