### PR TITLE
feat: Add --stdin and --and-push flags to dipeo compile for MCP integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,26 @@ dipeo export examples/simple_diagrams/simple_iter.light.yaml output.py --light
 ```
 See [Diagram-to-Python Export Guide](docs/features/diagram-to-python-export.md)
 
+### Compile and Push (for MCP)
+```bash
+# Validate from file
+dipeo compile my_diagram.light.yaml --light
+
+# Validate from stdin (LLM-friendly)
+echo '<diagram-content>' | dipeo compile --stdin --light
+
+# Compile and push to MCP directory
+dipeo compile my_diagram.light.yaml --light --and-push
+dipeo compile my_diagram.light.yaml --light --and-push --target-dir /custom/path
+```
+
+**Benefits:**
+- **Safe Upload**: Only valid diagrams are pushed
+- **No File Persistence**: LLMs can validate diagrams from text without filesystem access
+- **Automatic MCP Integration**: Pushed diagrams immediately available via `dipeo_run`
+
+See [MCP Server Integration](docs/features/mcp-server-integration.md#3-uploading-diagrams-for-mcp-access)
+
 ### Code Generation
 ```bash
 cd dipeo/models && pnpm build      # Build TypeScript specs

--- a/apps/server/src/dipeo_server/api/mcp_server.py
+++ b/apps/server/src/dipeo_server/api/mcp_server.py
@@ -193,6 +193,18 @@ class MCPServer:
 
             diagrams = []
 
+            # Check MCP diagrams directory (pushed via --and-push)
+            mcp_dir = Path("projects/mcp-diagrams")
+            if mcp_dir.exists():
+                for file in mcp_dir.glob("*.yaml"):
+                    diagrams.append(
+                        {"name": file.stem, "path": str(file), "format": "light"}
+                    )
+                for file in mcp_dir.glob("*.json"):
+                    diagrams.append(
+                        {"name": file.stem, "path": str(file), "format": "native"}
+                    )
+
             # Check examples directory
             examples_dir = Path("examples/simple_diagrams")
             if examples_dir.exists():

--- a/apps/server/src/dipeo_server/cli/entry_point.py
+++ b/apps/server/src/dipeo_server/cli/entry_point.py
@@ -206,10 +206,13 @@ async def run_cli_command(args: argparse.Namespace) -> bool:
                 format_type = "readable"
 
             return await cli.compile_diagram(
-                diagram_path=args.diagram,
+                diagram_path=getattr(args, "diagram", None),
                 format_type=format_type,
                 check_only=getattr(args, "check_only", False),
                 output_json=getattr(args, "json", False),
+                use_stdin=getattr(args, "stdin", False),
+                and_push=getattr(args, "and_push", False),
+                target_dir=getattr(args, "target_dir", None),
             )
 
         elif args.command == "list":
@@ -436,9 +439,12 @@ def create_parser() -> argparse.ArgumentParser:
 
     # Compile command
     compile_parser = subparsers.add_parser("compile", help="Validate and compile diagram")
-    compile_parser.add_argument("diagram", help="Path to diagram file or diagram name")
+    compile_parser.add_argument("diagram", nargs="?", help="Path to diagram file or diagram name (optional with --stdin)")
     compile_parser.add_argument("--check-only", action="store_true", help="Only validate structure")
     compile_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    compile_parser.add_argument("--stdin", action="store_true", help="Read diagram content from stdin")
+    compile_parser.add_argument("--and-push", dest="and_push", action="store_true", help="Push compiled diagram to MCP directory")
+    compile_parser.add_argument("--target-dir", dest="target_dir", type=str, help="Target directory for --and-push (default: projects/mcp-diagrams/)")
 
     # Format options
     compile_format_group = compile_parser.add_mutually_exclusive_group()

--- a/docs/features/mcp-server-integration.md
+++ b/docs/features/mcp-server-integration.md
@@ -75,7 +75,70 @@ curl -X POST http://localhost:8000/mcp/messages \
   }'
 ```
 
-### 3. Expose via ngrok
+### 3. Uploading Diagrams for MCP Access
+
+DiPeO provides a convenient way to make diagrams available via the MCP server using the `dipeo compile` command with the `--and-push` flag.
+
+#### From File
+
+Compile and upload an existing diagram file:
+
+```bash
+# Basic usage
+dipeo compile my_diagram.light.yaml --light --and-push
+
+# Custom target directory
+dipeo compile my_diagram.light.yaml --light --and-push --target-dir /custom/path
+```
+
+#### From stdin (for LLMs)
+
+LLMs can compile and validate diagrams directly from text without creating files:
+
+```bash
+# Using echo (for testing)
+echo 'nodes:
+  - id: start
+    type: start
+  - id: llm
+    type: llm_call
+    config:
+      model: gpt-5-nano-2025-08-07
+      system_prompt: "You are helpful"
+      user_prompt: "Hello"
+  - id: end
+    type: end
+arrows:
+  - from: start
+    to: llm
+  - from: llm
+    to: end' | dipeo compile --stdin --light
+
+# Using heredoc (for multi-line)
+dipeo compile --stdin --light << 'EOF'
+nodes:
+  - id: start
+    type: start
+  - id: end
+    type: end
+arrows:
+  - from: start
+    to: end
+EOF
+```
+
+**Benefits:**
+- **Safe Upload**: Only diagrams that pass compilation validation are pushed
+- **No File Persistence**: LLMs don't need filesystem access to validate diagrams
+- **Automatic MCP Integration**: Pushed diagrams are immediately available via `dipeo_run`
+
+**Note**: The `--stdin` flag cannot be used with `--and-push` because stdin input doesn't have a filename. To push a diagram from stdin, first save it to a file, then use `--and-push`.
+
+**Default Target Directory**: `projects/mcp-diagrams/`
+
+The MCP server automatically scans this directory, making all pushed diagrams available for execution.
+
+### 4. Expose via ngrok
 
 #### Install ngrok
 


### PR DESCRIPTION
## Summary

Implements stdin support and safe diagram upload for the `dipeo compile` command, enabling LLM-driven workflows with MCP integration.

## Changes

- ✅ Add `--stdin` flag for reading diagram content from stdin
- ✅ Add `--and-push` flag for automatic diagram upload to MCP directory
- ✅ Add `--target-dir` option for custom push directory
- ✅ Implement temporary file handling for stdin input
- ✅ Only push diagrams that pass compilation validation
- ✅ Update MCP server to scan `projects/mcp-diagrams/` directory
- ✅ Update documentation and CLAUDE.md

## Usage

```bash
# Validate from stdin (LLM-friendly)
echo '<diagram-content>' | dipeo compile --stdin --light

# Compile and push from file
dipeo compile my_diagram.light.yaml --light --and-push

# Custom target directory
dipeo compile my_diagram.light.yaml --light --and-push --target-dir /custom/path
```

## Benefits

- ✅ **No File Persistence Required**: LLMs can validate diagrams without filesystem access
- ✅ **Safe Upload**: Only validated diagrams are pushed
- ✅ **Automatic MCP Integration**: Pushed diagrams immediately available via `dipeo_run`
- ✅ **Flexible**: Supports both file-based and stdin-based workflows

## Documentation

- [MCP Server Integration Guide](docs/features/mcp-server-integration.md#3-uploading-diagrams-for-mcp-access)
- [CLAUDE.md](CLAUDE.md#compile-and-push-for-mcp)

Fixes #159

Generated with [Claude Code](https://claude.ai/code)