### PR TITLE
docs: fix light diagram format - use 'connections' not 'arrows'

### DIFF
--- a/docs/features/mcp-server-integration.md
+++ b/docs/features/mcp-server-integration.md
@@ -111,7 +111,7 @@ echo 'nodes:
       user_prompt: "Hello"
   - id: end
     type: end
-arrows:
+connections:
   - from: start
     to: llm
   - from: llm


### PR DESCRIPTION
Updated MCP server integration documentation to use the correct 'connections:' field name instead of 'arrows:' in light diagram examples. This matches the actual light diagram format used in working examples throughout the codebase.

Fixes #182

---
Generated with [Claude Code](https://claude.ai/code)